### PR TITLE
Minor optimizations to pointcloud downsampling

### DIFF
--- a/fineleg/src/pointcloud_utils.rs
+++ b/fineleg/src/pointcloud_utils.rs
@@ -11,43 +11,24 @@ pub fn voxel_downsample(
     // TODO: upgrade this so that user can specify number of points in final pointcloud (not trivial)
     let num_voxels_per_axis = (num_voxels_in_grid as f64).cbrt().round();
 
-    let pointcloud_df_lazy = pointcloud.lazy();
-
-    // These are one-off calculations, so we do them separately and broadcast them to the df with cross_join
-    let pointcloud_bounds = pointcloud_df_lazy
-        .clone()
-        .select([
-            col("x").min().alias("x_min"),
-            col("y").min().alias("y_min"),
-            col("z").min().alias("z_min"),
-            col("x").max().alias("x_max"),
-            col("y").max().alias("y_max"),
-            col("z").max().alias("z_max"),
-        ])
-        .with_columns([
-            (col("x_max") - col("x_min")).alias("x_range"),
-            (col("y_max") - col("y_min")).alias("y_range"),
-            (col("z_max") - col("z_min")).alias("z_range"),
-        ]);
-
     // TODO: Beware division by zero in here
-    pointcloud_df_lazy
-        .cross_join(pointcloud_bounds, None)
+    pointcloud
+        .lazy()
         .with_columns([
-            ((col("x_range")) / lit(num_voxels_per_axis)).alias("voxel_size_x"),
-            ((col("y_range")) / lit(num_voxels_per_axis)).alias("voxel_size_y"),
-            ((col("z_range")) / lit(num_voxels_per_axis)).alias("voxel_size_z"),
+            ((col("x").max() - col("x").min()) / lit(num_voxels_per_axis)).alias("voxel_size_x"),
+            ((col("y").max() - col("y").min()) / lit(num_voxels_per_axis)).alias("voxel_size_y"),
+            ((col("z").max() - col("z").min()) / lit(num_voxels_per_axis)).alias("voxel_size_z"),
         ])
         .with_columns([
-            ((col("x") - col("x_min")) / col("voxel_size_x"))
+            ((col("x") - col("x").min()) / col("voxel_size_x"))
                 .floor()
                 .cast(DataType::Int64)
                 .alias("voxel_idx_x"),
-            ((col("y") - col("y_min")) / col("voxel_size_y"))
+            ((col("y") - col("y").min()) / col("voxel_size_y"))
                 .floor()
                 .cast(DataType::Int64)
                 .alias("voxel_idx_y"),
-            ((col("z") - col("z_min")) / col("voxel_size_z"))
+            ((col("z") - col("z").min()) / col("voxel_size_z"))
                 .floor()
                 .cast(DataType::Int64)
                 .alias("voxel_idx_z"),
@@ -67,24 +48,16 @@ pub fn voxel_downsample(
 }
 
 pub fn center_pointcloud(pointcloud: DataFrame) -> PolarsResult<DataFrame> {
-    let pointcloud_df_lazy = pointcloud.lazy();
-
-    // These are one-off calculations, so we do them separately and broadcast them to the df below with cross_join
-    let means = pointcloud_df_lazy.clone().select([
-        col("x").mean().alias("x_mean"),
-        col("y").mean().alias("y_mean"),
-        col("z").mean().alias("z_mean"),
-    ]);
-
-    pointcloud_df_lazy
-        .cross_join(means, None)
+    pointcloud
+        .lazy()
         .with_columns([
-            (col("x") - col("x_mean")).alias("x"),
-            (col("y") - col("y_mean")).alias("y"),
-            (col("z") - col("z_mean")).alias("z"),
+            (col("x") - col("x").mean()).alias("x"),
+            (col("y") - col("y").mean()).alias("y"),
+            (col("z") - col("z").mean()).alias("z"),
         ])
         .collect()
 }
+
 pub fn load_las_to_df(path: &str) -> Result<DataFrame> {
     let mut reader = las::Reader::from_path(path)?;
 


### PR DESCRIPTION
Voxel downsampling of the pointcloud requires some one-off calculations like the min/max of each axis, as well as the range of each axis. I _thought_ it would be quicker to ensure I only compute these once (as opposed to once every row), so I ended up doing that in a separate expression, and using `cross_join `to broadcast those values into the dataframe to use for voxel calcs.

In practice, it seems I was being too clever for my own good. After timing it, it's actually quicker to just use expressions like `col("x").min()` in the main expression, presumably because the cost of the join is high, and because Polars is clever enough to not actually run unnecessary calculations like that. The lesson here is to trust the Polars query optimizer.

Worth noting that maybe there's a threshold of a number of points above which the join is too expensive, but below which the original approach is actually better; maybe I'll look into it someday. For reference, the pointcloud I used to time this had 21M points